### PR TITLE
Update Mailpit to v1.27 and add automated version updates

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -1,0 +1,156 @@
+name: Auto-update Mailpit versions
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  check-and-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check for new Mailpit versions
+        id: check-versions
+        run: |
+          # Get latest versions from Docker Hub
+          LATEST_VERSIONS=$(curl -s "https://registry.hub.docker.com/v2/repositories/axllent/mailpit/tags/?page_size=50" | \
+            jq -r '.results[].name' | \
+            grep -E '^v[0-9]+\.[0-9]+(\.[0-9]+)?$' | \
+            sed 's/^v//' | \
+            sort -V | \
+            tail -10)
+          
+          echo "Available versions:"
+          echo "$LATEST_VERSIONS"
+          
+          # Get the latest version
+          LATEST_VERSION=$(echo "$LATEST_VERSIONS" | tail -1)
+          echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          
+          # Get current version from plugin
+          CURRENT_VERSION=$(grep -o "version: '[^']*'" builders/mailpit.js | cut -d"'" -f2)
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          
+          # Check if update is needed
+          if [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+            echo "Update needed: $CURRENT_VERSION -> $LATEST_VERSION"
+          else
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+            echo "No update needed. Current version $CURRENT_VERSION is latest."
+          fi
+          
+          # Get the 3 most recent versions for supported list
+          SUPPORTED_VERSIONS=$(echo "$LATEST_VERSIONS" | tail -3 | tac | tr '\n' ',' | sed 's/,$//')
+          echo "supported_versions=$SUPPORTED_VERSIONS" >> $GITHUB_OUTPUT
+
+      - name: Update plugin files
+        if: steps.check-versions.outputs.needs_update == 'true'
+        run: |
+          LATEST_VERSION="${{ steps.check-versions.outputs.latest_version }}"
+          SUPPORTED_VERSIONS="${{ steps.check-versions.outputs.supported_versions }}"
+          
+          echo "Updating to version: $LATEST_VERSION"
+          echo "Supported versions: $SUPPORTED_VERSIONS"
+          
+          # Update builders/mailpit.js
+          node -e "
+            const fs = require('fs');
+            const path = 'builders/mailpit.js';
+            let content = fs.readFileSync(path, 'utf8');
+            
+            // Update default version
+            content = content.replace(
+              /version: '[^']*'/,
+              \"version: '$LATEST_VERSION'\"
+            );
+            
+            // Update supported versions array
+            const supportedArray = '$SUPPORTED_VERSIONS'.split(',').map(v => \"'\" + v + \"'\").join(', ');
+            content = content.replace(
+              /supported: \[[^\]]*\]/,
+              \"supported: [\" + supportedArray + \"]\"
+            );
+            
+            fs.writeFileSync(path, content);
+            console.log('Updated builders/mailpit.js');
+          "
+          
+          # Update examples - only replace the current default version
+          find examples -name "*.yml" -exec sed -i "s/mailpit:$CURRENT_VERSION/mailpit:$LATEST_VERSION/g" {} \;
+          echo "Updated examples"
+          
+          # Update README.md - only replace the current default version
+          sed -i "s/mailpit:$CURRENT_VERSION/mailpit:$LATEST_VERSION/g" README.md
+          echo "Updated README.md"
+          
+          # Update docs - only replace the current default version
+          find docs -name "*.md" -exec sed -i "s/mailpit:$CURRENT_VERSION/mailpit:$LATEST_VERSION/g" {} \;
+          echo "Updated docs"
+          
+          # Update supported versions list in docs/index.md
+          node -e "
+            const fs = require('fs');
+            const path = 'docs/index.md';
+            let content = fs.readFileSync(path, 'utf8');
+            
+            const versions = '$SUPPORTED_VERSIONS'.split(',');
+            const versionList = versions.map((v, i) => {
+              const isDefault = i === 0 ? ' **(default)**' : '';
+              return \"- \" + (i === 0 ? '**' : '') + \"[\" + v + \"](https://hub.docker.com/r/axllent/mailpit/)\" + (i === 0 ? '**' : '') + isDefault;
+            }).join('\n');
+            
+            // Replace the supported versions section
+            content = content.replace(
+              /- \*\*\[[\d.]+\]\(https:\/\/hub\.docker\.com\/r\/axllent\/mailpit\/\)\*\* \*\*\(default\)\*\*\n(?:- \[[\d.]+\]\(https:\/\/hub\.docker\.com\/r\/axllent\/mailpit\/\)\n?)*/,
+              versionList + '\n'
+            );
+            
+            fs.writeFileSync(path, content);
+            console.log('Updated supported versions in docs/index.md');
+          "
+
+      - name: Create Pull Request
+        if: steps.check-versions.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            Update Mailpit to v${{ steps.check-versions.outputs.latest_version }}
+            
+            - Updated default version from ${{ steps.check-versions.outputs.current_version }} to ${{ steps.check-versions.outputs.latest_version }}
+            - Updated supported versions to latest 3 releases
+            - Updated all examples and documentation
+          title: "Update Mailpit to v${{ steps.check-versions.outputs.latest_version }}"
+          body: |
+            ## Summary
+            - Updates Mailpit plugin to use the latest version v${{ steps.check-versions.outputs.latest_version }}
+            - Updates supported versions list to include the 3 most recent releases
+            - Updates all examples and documentation to reflect the new default version
+            
+            ## Changes
+            - **Plugin**: Updated default version and supported versions in `builders/mailpit.js`
+            - **Examples**: Updated version references in all example `.lando.yml` files
+            - **Documentation**: Updated version references in README.md and docs/
+            
+            ## Test plan
+            - [ ] Verify plugin loads with new version
+            - [ ] Test basic example works with new default version
+            - [ ] Test advanced example works with explicit version
+            - [ ] Verify documentation renders correctly
+            
+            ---
+            *This PR was automatically generated by GitHub Actions*
+          branch: auto-update-mailpit-v${{ steps.check-versions.outputs.latest_version }}
+          delete-branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+- Added support for `mailpit` v1.25 - v1.27
+- Updated `mailpit` default version to v1.27
+- Added automated GitHub Actions workflow for daily version updates
+
 ## v1.0.0 - [May 18, 2025](https://github.com/lando/mailpit/releases/tag/v1.0.0)
 
 - Added support for `mailpit` v1.23 - v1.25

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add a mailpit service to your landofile:
 ```yaml
 services:
   mailpit:
-    type: mailpit:1.25
+    type: mailpit:1.27
     mailFrom: # Defaults to appserver.
       - appserver
 

--- a/builders/mailpit.js
+++ b/builders/mailpit.js
@@ -31,8 +31,8 @@ const setConfigOptions = require('../utils/set-config-options');
  * @type {MailpitConfig}
  */
 const defaultConfig = {
-  version: '1.25',
-  supported: ['1.22', '1.23', '1.24', '1.25'],
+  version: '1.27',
+  supported: ['1.25', '1.26', '1.27'],
   mailFrom: ['appserver'],
   maxMessages: 500,
   port: 1025,

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,7 +12,7 @@ Also note that options, in addition to the [build steps](https://docs.lando.dev/
 ```yaml
 services:
   mailpit:
-    type: mailpit:1.25
+    type: mailpit:1.27
     mailFrom:
       - appserver
     maxMessages: 500
@@ -37,7 +37,7 @@ Example configuration with explicit mail service setup:
 ```yaml
 services:
   mailpit:
-    type: mailpit:1.25
+    type: mailpit:1.27
     mailFrom:
       - phpapp
   phpapp:
@@ -51,7 +51,7 @@ The maximum number of messages to store before truncating. Must be at least 1.
 ```yaml
 services:
   mailpit:
-    type: mailpit:1.25
+    type: mailpit:1.27
     maxMessages: 1000  # Store up to 1000 messages
 ```
 
@@ -62,7 +62,7 @@ The SMTP port to use for sending mail to Mailpit. Must be between 1 and 65535.
 ```yaml
 services:
   mailpit:
-    type: mailpit:1.25
+    type: mailpit:1.27
     port: 2525  # Use custom SMTP port
 ```
 
@@ -75,6 +75,6 @@ This option is inherited from the `lando` base service. It allows external acces
 ```yaml
 services:
   mailpit:
-    type: mailpit:1.25
+    type: mailpit:1.27
     portforward: true
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Add a mailpit service to your landofile.
 ```yaml
 services:
   mailpit:
-    type: mailpit:1.25
+    type: mailpit:1.27
     mailFrom: # Defaults to appserver.
       - appserver
 
@@ -70,8 +70,7 @@ To retrieve connection and credential details for your Mailpit instance, use the
 
 ## Supported versions
 
-- **[1.25](https://hub.docker.com/r/axllent/mailpit/)** **(default)**
-- [1.24](https://hub.docker.com/r/axllent/mailpit/)
-- [1.23](https://hub.docker.com/r/axllent/mailpit/)
-- [1.22](https://hub.docker.com/r/axllent/mailpit/)
+- **[1.27](https://hub.docker.com/r/axllent/mailpit/)** **(default)**
+- [1.26](https://hub.docker.com/r/axllent/mailpit/)
+- [1.25](https://hub.docker.com/r/axllent/mailpit/)
 - [custom](https://docs.lando.dev/services/lando-3.html#overrides)

--- a/examples/advanced/.lando.yml
+++ b/examples/advanced/.lando.yml
@@ -9,7 +9,7 @@ services:
     type: php:8.2
 
   smtpserver:
-    type: mailpit:1.22
+    type: mailpit:1.25
     maxMessages: 54321
     port: 2025
     mailFrom:

--- a/test/mailpit.spec.js
+++ b/test/mailpit.spec.js
@@ -13,7 +13,7 @@
  * @requires builders/mailpit
  */
 
-const DEFAULT_MAILPIT_VERSION = '1.25';
+const DEFAULT_MAILPIT_VERSION = '1.27';
 
 const chai = require('chai');
 const expect = chai.expect;


### PR DESCRIPTION
## Summary
- Updates Mailpit plugin to use the latest version v1.27
- Updates supported versions to include the 3 most recent releases
- Adds automated GitHub Actions workflow for future version updates

## Changes
- **Plugin**: Updated default version from 1.25 to 1.27 in `builders/mailpit.js`
- **Examples**: Updated version references in example `.lando.yml` files
- **Documentation**: Updated version references in README.md and docs/
- **Automation**: Added `.github/workflows/auto-update-versions.yml` for daily version checks

## Test plan
- [x] Verify plugin loads with new version
- [x] Test basic example works with new default version  
- [x] Test advanced example works with explicit version
- [x] Verify documentation renders correctly
- [ ] Test automated workflow (will run on schedule)

🤖 Generated with [opencode](https://opencode.ai)